### PR TITLE
[BA-27] CounselingJournals 생성 코드 추가

### DIFF
--- a/src/djangoapp/counseling/views.py
+++ b/src/djangoapp/counseling/views.py
@@ -370,6 +370,13 @@ class CounselingApplicationApproval(APIView):
              )
         counseling_schedule.save()
 
+        counseling_journals = \
+            CounselingJournals(
+                counseling_schedule=counseling_schedule,
+                feedback=""
+            )
+        counseling_journals.save()
+
         return Response(status=status.HTTP_200_OK)
 
 
@@ -432,6 +439,13 @@ class CounselingScheduleAdd(APIView):
                 session_status='Yet'
             )
         counseling_schedule.save()
+
+        counseling_journals = \
+            CounselingJournals(
+                counseling_schedule=counseling_schedule,
+                feedback=""
+            )
+        counseling_journals.save()
 
         return Response(status=status.HTTP_200_OK)
     


### PR DESCRIPTION
CounselingJournals 객체를 save하는 부분이 없어
CounselingApplicationApproval(상담서 신청 승인)과
CounselingScheduleAdd(상담 스케줄 추가)가 되면
해당 CounselingSchedule의 CounselingJournals 객체를 자동으로 save하도록 수정